### PR TITLE
Add new michelin frame types & fix a few issue.

### DIFF
--- a/custom_components/tpms_ble/tpms_parser/parser.py
+++ b/custom_components/tpms_ble/tpms_parser/parser.py
@@ -50,8 +50,8 @@ class TPMSBluetoothDeviceData(BluetoothData):
             self._process_tpms_a(address, local_name, mfr_data)
         elif company_id == 2088:
             self._process_tpms_c(address, local_name, mfr_data)
-        #else:
-        #    _LOGGER.error("Can't find the correct data type")
+        else:
+            _LOGGER.debug("Can't find the correct data type")
 
     def _process_tpms_a(self, address: str, local_name: str, data: bytes) -> None:
         """Parser for TPMS sensors."""


### PR DESCRIPTION
Remove a useless log error
Add Michelin frame types 0x02, 0x04, 0x05, 0x06, 0x0c, including some that do not have pressure measurement.
Unsuccessfully tried to improve the display of battery voltage to 2 digit... :(

Successfully tested!