### PR TITLE
Add Data Age sensor to track time since last BLE update

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,6 @@ Easiest install is via [HACS](https://hacs.xyz/):
 
 The device will be autodiscovered once the data are received by any bluetooth proxy.
 
-## Data Age Sensor
-
-The Data Age sensor tracks how many minutes have elapsed since the last BLE advertisement was received from each TPMS sensor. This is useful for monitoring whether your sensors are actively broadcasting.
-
-- **Value of 0**: Data is less than 1 minute old
-- **Update frequency**: The sensor value updates once per minute
-- **Availability**: Shows as unavailable until the first BLE update is received
-
-### Upgrading from Previous Versions
-
-If you are upgrading from a version without the Data Age sensor, the new sensor may initially appear as a separate "Unnamed device" entry. To fix this:
-
-1. Delete the TPMS device from Home Assistant (Settings → Devices & Services → Devices)
-2. The device will be automatically rediscovered with all sensors properly grouped
-3. All previously configured attributes (names, areas, etc.) will be restored from the entity registry
-
 ## Supported Devices
 ### Type A
 Android App: [TPMSII](https://play.google.com/store/apps/details?id=com.chaoyue.tyed) 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Exposes the following sensors:
  - Pressure
  - Temperature
  - Voltage
+ - Data Age (minutes since last BLE update)
 
 ## Installation
 
@@ -22,6 +23,22 @@ Easiest install is via [HACS](https://hacs.xyz/):
 `HACS -> Explore & Add Repositories -> TPMS_BLE`
 
 The device will be autodiscovered once the data are received by any bluetooth proxy.
+
+## Data Age Sensor
+
+The Data Age sensor tracks how many minutes have elapsed since the last BLE advertisement was received from each TPMS sensor. This is useful for monitoring whether your sensors are actively broadcasting.
+
+- **Value of 0**: Data is less than 1 minute old
+- **Update frequency**: The sensor value updates once per minute
+- **Availability**: Shows as unavailable until the first BLE update is received
+
+### Upgrading from Previous Versions
+
+If you are upgrading from a version without the Data Age sensor, the new sensor may initially appear as a separate "Unnamed device" entry. To fix this:
+
+1. Delete the TPMS device from Home Assistant (Settings → Devices & Services → Devices)
+2. The device will be automatically rediscovered with all sensors properly grouped
+3. All previously configured attributes (names, areas, etc.) will be restored from the entity registry
 
 ## Supported Devices
 ### Type A

--- a/custom_components/tpms_ble/__init__.py
+++ b/custom_components/tpms_ble/__init__.py
@@ -25,7 +25,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     address = entry.unique_id
     assert address is not None
     data = TPMSBluetoothDeviceData()
-    coordinator = hass.data.setdefault(DOMAIN, {})[
+    hass.data.setdefault(DOMAIN, {})
+    # Store device data for sensor platform to access
+    hass.data[DOMAIN][f"{entry.entry_id}_data"] = data
+    coordinator = hass.data[DOMAIN][
         entry.entry_id
     ] = PassiveBluetoothProcessorCoordinator(
         hass,
@@ -45,5 +48,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(f"{entry.entry_id}_data", None)
 
     return unload_ok

--- a/custom_components/tpms_ble/manifest.json
+++ b/custom_components/tpms_ble/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/bkbilly/tpms_ble/issues",
   "requirements": [],
-  "version": "1.5.0"
+  "version": "1.5.1"
 }

--- a/custom_components/tpms_ble/manifest.json
+++ b/custom_components/tpms_ble/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/bkbilly/tpms_ble/issues",
   "requirements": [],
-  "version": "1.4.2"
+  "version": "1.5.0"
 }

--- a/custom_components/tpms_ble/sensor.py
+++ b/custom_components/tpms_ble/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Callable, Optional, Union
+from typing import Callable
 
 from .tpms_parser import TPMSSensor, SensorUpdate, TPMSBluetoothDeviceData
 
@@ -27,9 +27,10 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfTime,
 )
-from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
+from homeassistant.components.bluetooth.const import DOMAIN as BLUETOOTH_DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
@@ -134,16 +135,35 @@ async def async_setup_entry(
         # Create data age sensor once we have device info
         if not data_age_sensor_created and processor.devices:
             data_age_sensor_created = True
-            # Get base device info and add Bluetooth connection for device matching
+
+            # Get base device info from processor for manufacturer/model
             base_info = next(iter(processor.devices.values()), {})
-            device_info = DeviceInfo(
-                connections={(CONNECTION_BLUETOOTH, coordinator.address)},
-                manufacturer=base_info.get("manufacturer"),
-                model=base_info.get("model"),
-                name=base_info.get("name"),
+
+            # Build device_info with identifiers/connections to link to the
+            # same device as the other TPMS sensors
+            device_info: DeviceInfo = {
+                "identifiers": {(BLUETOOTH_DOMAIN, coordinator.address)},
+                "connections": {(CONNECTION_BLUETOOTH, coordinator.address)},
+            }
+            if manufacturer := base_info.get("manufacturer"):
+                device_info["manufacturer"] = manufacturer
+            if model := base_info.get("model"):
+                device_info["model"] = model
+
+            # Get device name from registry - prefer user-customized name
+            dev_reg = dr.async_get(hass)
+            device = dev_reg.async_get_device(
+                identifiers={(BLUETOOTH_DOMAIN, coordinator.address)}
             )
+            if device:
+                entity_device_name = device.name_by_user or device.name
+            else:
+                entity_device_name = base_info.get(
+                    "name", f"TPMS {coordinator.address[-5:].replace(':', '')}"
+                )
+
             data_age_sensor = TPMSDataAgeSensorEntity(
-                hass, coordinator, device_data, device_info
+                hass, coordinator, device_data, device_info, entity_device_name
             )
             async_add_entities([data_age_sensor])
 
@@ -189,7 +209,7 @@ class TPMSBluetoothSensorEntity(
 class TPMSDataAgeSensorEntity(SensorEntity):
     """Representation of a TPMS data age sensor."""
 
-    _attr_has_entity_name = True
+    _attr_has_entity_name = False
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfTime.MINUTES
@@ -202,13 +222,14 @@ class TPMSDataAgeSensorEntity(SensorEntity):
         coordinator: PassiveBluetoothProcessorCoordinator,
         device_data: TPMSBluetoothDeviceData,
         device_info: DeviceInfo | None,
+        device_name: str,
     ) -> None:
         """Initialize the data age sensor."""
         self.hass = hass
         self._coordinator = coordinator
         self._device_data = device_data
-        self._attr_unique_id = f"{coordinator.address}_data_age"
-        self._attr_name = "Data Age"
+        self._attr_unique_id = f"{coordinator.address}_data_age_v2"
+        self._attr_name = f"{device_name} Data Age"
         self._attr_device_info = device_info
         self._unsub_timer: Callable[[], None] | None = None
 

--- a/custom_components/tpms_ble/sensor.py
+++ b/custom_components/tpms_ble/sensor.py
@@ -1,9 +1,10 @@
 """Support for TPMS sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional, Union
 
-from .tpms_parser import TPMSSensor, SensorUpdate
+from .tpms_parser import TPMSSensor, SensorUpdate, TPMSBluetoothDeviceData
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -24,10 +25,14 @@ from homeassistant.const import (
     UnitOfElectricPotential,
     UnitOfPressure,
     UnitOfTemperature,
+    UnitOfTime,
 )
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .const import DOMAIN
@@ -68,6 +73,14 @@ SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
+    TPMSSensor.DATA_AGE: SensorEntityDescription(
+        key=TPMSSensor.DATA_AGE,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        icon="mdi:clock-outline",
+    ),
 }
 
 
@@ -106,10 +119,37 @@ async def async_setup_entry(
     coordinator: PassiveBluetoothProcessorCoordinator = hass.data[DOMAIN][
         entry.entry_id
     ]
+    device_data: TPMSBluetoothDeviceData = hass.data[DOMAIN][f"{entry.entry_id}_data"]
+
     processor = PassiveBluetoothDataProcessor(sensor_update_to_bluetooth_data_update)
+
+    # Track whether data age sensor has been created
+    data_age_sensor_created = False
+
+    def _async_add_entities_with_data_age(entities: list) -> None:
+        """Add entities and create data age sensor on first update."""
+        nonlocal data_age_sensor_created
+        # Add the regular TPMS entities
+        async_add_entities(entities)
+        # Create data age sensor once we have device info
+        if not data_age_sensor_created and processor.devices:
+            data_age_sensor_created = True
+            # Get base device info and add Bluetooth connection for device matching
+            base_info = next(iter(processor.devices.values()), {})
+            device_info = DeviceInfo(
+                connections={(CONNECTION_BLUETOOTH, coordinator.address)},
+                manufacturer=base_info.get("manufacturer"),
+                model=base_info.get("model"),
+                name=base_info.get("name"),
+            )
+            data_age_sensor = TPMSDataAgeSensorEntity(
+                hass, coordinator, device_data, device_info
+            )
+            async_add_entities([data_age_sensor])
+
     entry.async_on_unload(
         processor.async_add_entities_listener(
-            TPMSBluetoothSensorEntity, async_add_entities
+            TPMSBluetoothSensorEntity, _async_add_entities_with_data_age
         )
     )
     entry.async_on_unload(
@@ -144,3 +184,68 @@ class TPMSBluetoothSensorEntity(
     def assumed_state(self) -> bool:
         """Return True if the device is no longer broadcasting."""
         return not self.processor.available
+
+
+class TPMSDataAgeSensorEntity(SensorEntity):
+    """Representation of a TPMS data age sensor."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:clock-outline"
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: PassiveBluetoothProcessorCoordinator,
+        device_data: TPMSBluetoothDeviceData,
+        device_info: DeviceInfo | None,
+    ) -> None:
+        """Initialize the data age sensor."""
+        self.hass = hass
+        self._coordinator = coordinator
+        self._device_data = device_data
+        self._attr_unique_id = f"{coordinator.address}_data_age"
+        self._attr_name = "Data Age"
+        self._attr_device_info = device_info
+        self._unsub_timer: Callable[[], None] | None = None
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the data age in minutes."""
+        if self._device_data.last_update_time is None:
+            return None
+
+        age_seconds = (
+            datetime.now(timezone.utc) - self._device_data.last_update_time
+        ).total_seconds()
+
+        return int(age_seconds // 60)
+
+    @property
+    def available(self) -> bool:
+        """Return True if we have received at least one update."""
+        return self._device_data.last_update_time is not None
+
+    async def async_added_to_hass(self) -> None:
+        """Register timer when entity is added."""
+        await super().async_added_to_hass()
+
+        async def _async_update_data_age(now: datetime) -> None:
+            """Trigger state update for data age."""
+            self.async_write_ha_state()
+
+        self._unsub_timer = async_track_time_interval(
+            self.hass,
+            _async_update_data_age,
+            timedelta(minutes=1),
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clean up timer when entity is removed."""
+        if self._unsub_timer is not None:
+            self._unsub_timer()
+            self._unsub_timer = None
+        await super().async_will_remove_from_hass()

--- a/custom_components/tpms_ble/tpms_parser/parser.py
+++ b/custom_components/tpms_ble/tpms_parser/parser.py
@@ -1,6 +1,6 @@
 """Parser for TPMS BLE advertisements."""
 from __future__ import annotations
-from datetime import datetime
+from datetime import datetime, timezone
 
 import re
 import logging
@@ -23,6 +23,7 @@ class TPMSSensor(StrEnum):
     BATTERY = "battery"
     VOLTAGE = "voltage"
     SIGNAL_STRENGTH = "signal_strength"
+    DATA_AGE = "data_age"
 
 
 class TPMSBinarySensor(StrEnum):
@@ -31,6 +32,16 @@ class TPMSBinarySensor(StrEnum):
 
 class TPMSBluetoothDeviceData(BluetoothData):
     """Data for TPMS BLE sensors."""
+
+    def __init__(self) -> None:
+        """Initialize the TPMS device data."""
+        super().__init__()
+        self._last_update_time: datetime | None = None
+
+    @property
+    def last_update_time(self) -> datetime | None:
+        """Return the timestamp of the last BLE update."""
+        return self._last_update_time
 
     def _start_update(self, service_info: BluetoothServiceInfo) -> None:
         """Update from BLE advertisement data."""
@@ -168,6 +179,7 @@ class TPMSBluetoothDeviceData(BluetoothData):
         )
 
     def _update_sensors(self, address, pressure, battery_pct, temperature, alarm, voltage):
+        self._last_update_time = datetime.now(timezone.utc)
         name = f"TPMS {short_address(address)}"
         self.set_device_type(name)
         self.set_device_name(name)


### PR DESCRIPTION
## Summary

Adds a new "Data Age" sensor that displays the number of minutes elapsed since the last BLE advertisement was received from each TPMS sensor. This is useful for monitoring whether TPMS sensors are actively broadcasting.

- Value of **0** indicates data is less than 1 minute old
- Sensor updates once per minute via timer
- Shows as unavailable until first BLE data is received
- Properly grouped with other TPMS sensors on the same device

## Changes

- **parser.py**: Add `DATA_AGE` enum value, add timestamp tracking to `TPMSBluetoothDeviceData` class
- **__init__.py**: Store `device_data` instance for sensor platform access
- **sensor.py**: Add `TPMSDataAgeSensorEntity` class with periodic 1-minute timer
- **README.md**: Document new sensor behavior and upgrade instructions

## Test plan

- [x] Verify Data Age sensor appears under the correct TPMS device
- [x] Verify value shows 0 when BLE data is less than 1 minute old
- [x] Verify value increments each minute when no new BLE data received
- [x] Verify value resets to 0 when new BLE data arrives
- [x] Verify sensor shows as unavailable until first BLE update

🤖 Generated with [Claude Code](https://claude.com/claude-code)